### PR TITLE
Fix hidden piece

### DIFF
--- a/app/src/main/java/de/mwvb/blockpuzzle/MainActivity.kt
+++ b/app/src/main/java/de/mwvb/blockpuzzle/MainActivity.kt
@@ -116,6 +116,11 @@ class MainActivity : AppCompatActivity(), IGameView {
                 }
                 MotionEvent.ACTION_UP -> {
                     game.rotate(index)
+                    // Da ich nicht weiß, welcher ausgeblendet ist, blende ich einfach alle ein.
+                    getGamePieceView(1).endDragMode()
+                    getGamePieceView(2).endDragMode()
+                    getGamePieceView(3).endDragMode()
+                    getGamePieceView(-1).endDragMode()
                     true
                 }
                 else -> {


### PR DESCRIPTION
If a piece is pressed for a longer time and probably moved a few pixels it disappears (is hidden) sometimes, see #14 for more details.

This pull request should fix the issue.